### PR TITLE
Resolve issue with Fleet server settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,14 +15,20 @@ Filebeat and Metricbeat are installed solely for monitoring Elasticsearch nodes 
     ./submit-es-fleet-addresses.sh
     ```
 
-2. To add external hosts as Elastic Agents, you need to specify the Fully Qualified Domain Name (FQDN) or IP address of your host where Docker is running to generate certificates (to include SAN entry in the certificate).
+2. To add external hosts as Elastic Agents, you need to specify the Fully Qualified Domain Name (FQDN) or IP address of your host where Docker is running to generate certificates (to include SAN entry in the certificate):
 
     ```bash
     chmod +x generate_kibana_encryptionkeys.sh
     ./generate_kibana_encryptionkeys.sh
     ```
 
-3. Build and run:
+3. Make all the scripts in the custom-scripts directory executable:
+
+    ```bash
+    chmod +x custom-scripts/*
+    ```
+
+4. Build and run:
 
     ```bash
     docker compose build

--- a/README.md
+++ b/README.md
@@ -31,14 +31,9 @@ Filebeat and Metricbeat are installed solely for monitoring Elasticsearch nodes 
 
 After running the containers, you will find the `elasticsearch-ca.pem` certificate in the `certs/` directory. Use it to establish secure communications when adding Elastic Agents.
 
-When generating the installation script for Elastic Agent (from Kibana GUI), replace the hostname `fleet-server` with your host's IP or FQDN submitted to the `.env` file.
-
 In the `config` directory, you will find configuration files for Kibana, Metricbeat, Filebeat, and the Elasticsearch module for Filebeat.
 
 In the `custom-scripts` directory, you can find setup scripts for Elasticsearch, Kibana, Fleet, and certificate generation.
-
-> [!IMPORTANT]
-> Update the hosts file with the entries for es01 and fleet-server on your elastic-agent host (ES_SERVER_HOST and FLEET_SERVER_HOST does not work for now)
 
 # To-Do
 

--- a/custom-scripts/fleet-setup.sh
+++ b/custom-scripts/fleet-setup.sh
@@ -10,13 +10,13 @@ echo "Creating a Package Policy"
 curl --cacert /certs/elasticsearch-ca.pem -s -u "elastic:${ELASTIC_PASSWORD}" \
     -XPOST -H "kbn-xsrf: kibana" -H "Content-type: application/json" \
     "https://kibana:5601/api/fleet/package_policies" \
-    -d '{"name":"Elastic-System-package","namespace":"default","policy_id":"elastic-policy", "package":{"name": "system", "version":"1.54.0"}}' > /dev/null
+    -d '{"name":"Elastic-System-package","namespace":"default","policy_id":"elastic-policy", "package":{"name": "system", "version":"1.55.2"}}' > /dev/null
 
 echo "Adding a Fleet Server host"
 curl --cacert /certs/elasticsearch-ca.pem -s -u "elastic:${ELASTIC_PASSWORD}" \
     -XPUT -H "kbn-xsrf: kibana" -H "Content-type: application/json" \
     "https://kibana:5601/api/fleet/settings" \
-    -d '{"fleet_server_hosts": ["https://fleet-server:8220"]}' > /dev/null
+    -d '{"fleet_server_hosts": ["https://'${FLEET_SERVER_HOST}':8220"]}' > /dev/null
 
 # CATing /certs/elasticsearch-ca.pem
 cert_content=$(cat /certs/elasticsearch-ca.pem)
@@ -38,6 +38,6 @@ curl --cacert /certs/elasticsearch-ca.pem -s -u "elastic:${ELASTIC_PASSWORD}" \
     -XPUT -H "kbn-xsrf: kibana" -H "Content-type: application/json" \
     "https://kibana:5601/api/fleet/outputs/fleet-default-output" \
     -d '{
-      "hosts": ["https://es01:9200"],
+      "hosts": ["https://'${ES_SERVER_HOST}':9200"],
       "config_yaml": "'"$new_variable"'"
     }' > /dev/null


### PR DESCRIPTION
Fleet server hosts and Outputs (Kibana fleet settings) now use ES_SERVER_HOST and FLEET_SERVER_HOST variables for host IP.